### PR TITLE
implement option parsing

### DIFF
--- a/board.rb
+++ b/board.rb
@@ -37,22 +37,9 @@ class Board
   def initialize
     @grid = Array.new(8) { Array.new(8) {NullPiece.instance} }
     @can_empassant = false
-    self.set_board
   end
 
-#color, pos, board, symbol
-  def set_board
-    board_string = %{
-      rnbqkbnr
-      pppppppp
-      ________
-      ________
-      ________
-      ________
-      PPPPPPPP
-      RNBQKBNR
-    }
-
+  def set_board(board_string)
     grid = board_string.strip().split("\n").map{|row| row.strip().split('')}
     raise 'Invalid board' unless grid.size() == 8 and grid.all?{|row| row.size() == 8}
 

--- a/command_line_options.rb
+++ b/command_line_options.rb
@@ -1,0 +1,26 @@
+require 'optparse'
+
+# Class for parsing command line options passed to the program using the ruby optparse library.
+class CommandLineOptions
+
+  # Returns a map of options for various values configuring the game play.
+  def self.parse()
+    # initialize the default values of the options map
+    options = {
+      :fast => FALSE,
+      :board => 'data/initial_board.txt'
+    }
+
+    # create an options parser with names and descriptions
+    parser = OptionParser.new do |opts|
+      opts.on('-b', '--board PATH', "Specify the initial board file. (default: #{options[:board]})") { |o| options[:board] = o }
+      opts.on('-f', '--fast', 'Don\'t sleep between instructions.') { |o| options[:fast] = TRUE }
+      opts.on('-h', '--help', 'Prints this help') {|o| puts(opts); exit }
+    end
+
+    # parse the command line options using the parser, which will populate the options map
+    parser.parse!
+
+    return options
+  end
+end

--- a/data/initial_board.txt
+++ b/data/initial_board.txt
@@ -1,0 +1,9 @@
+rnbqkbnr
+pppppppp
+________
+________
+________
+________
+PPPPPPPP
+RNBQKBNR
+white to move

--- a/game.rb
+++ b/game.rb
@@ -1,4 +1,5 @@
 require_relative 'board'
+require_relative 'command_line_options'
 require_relative 'cursor'
 require_relative 'display'
 require_relative 'human_player'
@@ -9,12 +10,16 @@ class Game
   attr_accessor :turn
 
   def initialize
-    @board = Board.new
-    board.set_board
+    @options = CommandLineOptions.parse()
+    @board = Board.new()
+
+    board_lines = File.readlines(@options[:board]).reject { |line| line.strip.empty? }
+    @board.set_board(board_lines.slice(0,8).join())
+    @turn = (board_lines[-1].downcase.include?('black')) ? :black : :white
+
     @display = Display.new(@board)
     @player1 = HumanPlayer.new('Sam', self, :white)
     @player2 = HumanPlayer.new('Bob', self, :black)
-    @turn = :white
   end
 
   def render
@@ -70,7 +75,6 @@ class Game
   end
 
   def render_welcome
-
     puts "Welcome to..."
     puts".______       __    __   _______     _______.     _______.".colorize(:blue)
     puts"|   _  \\     |  |  |  | |   ____|   /       |    /       |".colorize(:blue)
@@ -81,31 +85,31 @@ class Game
     puts ""
     puts "... #{"ruby".colorize(:red)} chess in the console."
     puts ""
-    sleep(1)
+    pause(1)
     puts "Gameplay is simple."
-    sleep(1)
+    pause(1)
     puts "Play against yourself or a friend by using the space-bar."
-    sleep(1.5)
+    pause(1.5)
     puts ""
     puts "Press #{"SPACE".colorize(:green)} to pick a piece up."
-    sleep (1.25)
+    pause(1.25)
     puts "Use the #{"ARROW KEYS".colorize(:magenta)} to move the cursor around."
-    sleep (1.25)
+    pause(1.25)
     puts "Press #{"SPACE".colorize(:green)} to put the piece down."
-    sleep(2)
+    pause(2)
     puts ""
     puts "If you are using a MAC, press #{("\u2318" + " AND +").colorize(:cyan)} to zoom in/enlarge the board."
     puts ""
-    sleep(1.5)
+    pause(1.5)
     puts "Selected pieces are highlighted #{"YELLOW".colorize(:yellow)}."
-    sleep(1)
+    pause(1)
     puts "The cursor's position is highlighted #{"RED".colorize(:light_red)}."
-    sleep(1.5)
+    pause(1.5)
     puts "The game should finish automatically when one of you has won."
-    sleep(1)
+    pause(1)
     puts ""
     puts "Thats it! Enjoy!"
-    sleep(1)
+    pause(1)
     puts "Press #{"ENTER".colorize(:light_magenta)} when you're ready to play."
     input = gets
     until input == "\n"
@@ -113,6 +117,11 @@ class Game
       input = gets
     end
     system('clear')
+  end
+
+  def pause(amount)
+    rate = @options[:fast] ? 0 : 1
+    sleep(rate * amount)
   end
 
 end


### PR DESCRIPTION
# Context

This PR adds the functionality to pass arguments to the chess program from the command line.

For example, now you can see the command line options by typing:

```bash
$ ruby game.rb -h
Usage: game [options]
    -b, --board PATH                 Specify the initial board file. (default: data/initial_board.txt)
    -f, --fast                       Don't sleep between instructions.
    -h, --help                       Prints this help
```

You can start the program using:
```bash
$ ruby game.rb -f
```
which will remove the `sleep` calls during startup, which make debugging annoying

You can also now specify a board state to load from a file:
```bash
$ ruby game.rb -b data/initial_board.txt
```

Where the format of the board is as follows:
```bash
$ cat data/initial_board.txt 
rnbqkbnr
pppppppp
________
________
________
________
PPPPPPPP
RNBQKBNR
white to move
```

Starting the game with no options specified will produce the same behavior as before.

# Changes
 -  Adds a new `command_line_options.rb` file for parsing command-line options
 - `game.rb` calls the command-line options to get a map of option values.
 - `game.rb` does not sleep as long if the `-f` flag is passed.
 - `game.rb` loads the board position from a file and passes it to `board.rb`.
 - `game.rb` sets the next player to move using the value read from the board file.

# Testing Done
- Ran the program with each of the various flags passed and confirmed the behavior was as expected.
- Tried tweaking the initial board file and confirmed it was reflected in the board set up.

# Future Work
- possibly tweak the board reading file to allow setting more complex state (e.g. whether castling is possible, etc)
- make the board reading robust to whitespace and comments
- possibly support reading additional formats?

# Deploy Dependencies
N/A

# Related PRs (if applicable)
- #1 introduces the logic for parsing the board state

# Relevant Issues
N/A
