### PR TITLE
implement saving

### DIFF
--- a/board.rb
+++ b/board.rb
@@ -40,7 +40,7 @@ class Board
   end
 
   def set_board(board_string)
-    grid = board_string.strip().split("\n").map{|row| row.strip().split('')}
+    grid = board_string.gsub(' ', '').strip().split("\n").map{|row| row.strip().split('')}
     raise 'Invalid board' unless grid.size() == 8 and grid.all?{|row| row.size() == 8}
 
     for row,x in grid.each_with_index

--- a/board.rb
+++ b/board.rb
@@ -40,7 +40,7 @@ class Board
   end
 
   def set_board(board_string)
-    grid = board_string.gsub(' ', '').strip().split("\n").map{|row| row.strip().split('')}
+    grid = board_string.gsub(' ', '').strip.split("\n").map{|row| row.strip.chars}
     raise 'Invalid board' unless grid.size() == 8 and grid.all?{|row| row.size() == 8}
 
     for row,x in grid.each_with_index

--- a/cursor.rb
+++ b/cursor.rb
@@ -95,11 +95,11 @@ class Cursor
 
   def save
     filename = nil
-    puts "\n\nEnter a location where to save the game (leave blank to cancel)"
+    puts "\n\nEnter FILENAME to save the game. Game will be saved in ./data/<FILENAME>.txt (leave blank to cancel)"
     while !filename
       line = gets.chomp
       break if line.empty?
-      path = "./data/#{line}"
+      path = "./data/#{line}.txt"
       if File.exist?(path)
         puts "File '#{path}' already exists. Enter a new name (leave blank to cancel)"
       else

--- a/cursor.rb
+++ b/cursor.rb
@@ -21,6 +21,7 @@ KEYMAP = {
   "\177" => :backspace,
   "\004" => :delete,
   "\u0003" => :ctrl_c,
+  "S" => :save
 }
 
 MOVES = {
@@ -33,12 +34,13 @@ MOVES = {
 class Cursor
 
   attr_reader :board
-  attr_accessor :cursor_pos, :move_buffer
+  attr_accessor :cursor_pos, :move_buffer, :output_filename
 
   def initialize(cursor_pos, board)
     @cursor_pos = cursor_pos
     @board = board
     @move_buffer = []
+    @output_filename = nil
   end
 
   def get_input
@@ -78,14 +80,33 @@ class Cursor
   end
 
   def handle_key(key)
-    if [:left, :right, :up, :down].include?(key)
+    case key
+    when :left, :right, :up, :down
       diff = MOVES[key]
       update_pos(diff)
-    elsif key == :space
+    when :space
       move_buffer << @cursor_pos
-    elsif key == :ctrl_c
+    when :ctrl_c
       exit
+    when :save
+      save
     end
+  end
+
+  def save
+    filename = nil
+    puts "\n\nEnter a location where to save the game (leave blank to cancel)"
+    while !filename
+      line = gets.chomp
+      break if line.empty?
+      path = "./data/#{line}"
+      if File.exist?(path)
+        puts "File '#{path}' already exists. Enter a new name (leave blank to cancel)"
+      else
+        filename = path
+      end
+    end
+    @output_filename = filename
   end
 
   def update_pos(diff)

--- a/display.rb
+++ b/display.rb
@@ -26,4 +26,19 @@ class Display
       print "\n"
     end
   end
+
+  def render_to_string
+    s = ''
+    @board.grid.each_with_index do |row, i|
+      row.each_with_index do |piece, j|
+        if piece.instance_of? NullPiece
+          s += ' _ '
+        else
+          s += piece.symbol
+        end
+      end
+      s += "\n"
+    end
+    return s
+  end
 end

--- a/game.rb
+++ b/game.rb
@@ -74,6 +74,15 @@ class Game
     puts winner
   end
 
+  def save(path)
+    puts("Saving game to #{path}")
+    sleep(2)
+    File.open(path, 'w') { |file|
+      file.write(@display.render_to_string())
+      file.write("#{self.turn} to move.")
+    }
+  end
+
   def render_welcome
     puts "Welcome to..."
     puts".______       __    __   _______     _______.     _______.".colorize(:blue)

--- a/human_player.rb
+++ b/human_player.rb
@@ -24,12 +24,19 @@ class HumanPlayer
     end
   end
 
+  def handle_saving
+    return if not display.cursor.output_filename
+    game.save(display.cursor.output_filename)
+    display.cursor.output_filename = nil
+  end
+
   def make_move
     while game.turn == self.color && !game.game_over?
 
     game.render
     display.cursor.get_input
     self.handle_cheating
+    self.handle_saving
 
       if display.cursor.move_buffer.length == 2
         start, dest = display.cursor.move_buffer


### PR DESCRIPTION
# Context

This PR adds the functionality to save the board state to a file.

# Changes

## cursor.rb
- adds `save` method that reads a filename from the terminal and verifies that it doesn't already exist
- adds a new command that supports saving, current chosen to be capital `S`
- adds an `output_filename` property 
- changes reading logic to use a `case ... when` construct to be slightly tighter

# display.rb
- implement `render_to_string` method which is like `render`, but returns the string for facilitating saving to a file

# game.rb
- new save method which *actually* writes the board and the current player to move to a file

# human_player.rb
- added handler for saving

## board.rb
- makes loading board more robust (extra spaces don't throw off the board parsing)

# Testing Done

- Confirmed loading from a saved file works as expected.

- Tested the various code paths for saving to a new and existing file:

```
 ♜  ♞  ♝  ♛  ♚  ♝  ♞  ♜ 
 ♟  ♟  ♟  ♟  ♟  ♟  ♟  ♟ 
                        
                        
                        
                        
 ♙  ♙  ♙  ♙  ♙  ♙  ♙  ♙ 
 ♖  ♘  ♗  ♕  ♔  ♗  ♘  ♖ 
White in check?:  false
Black in check?:  false
White in checkmate?: false
Black in checkmate?: false
The move buffer: []
white to move.


Enter a location where to save the game (leave blank to cancel)
foo
File './data/foo' already exists. Enter a new name (leave blank to cancel)

```


# Future Work
N/A

# Deploy Dependencies
N/A

# Related PRs (if applicable)
- #2 is related in that it adds support for reading the board from a file

# Relevant Issues
N/A
